### PR TITLE
Align local and serverless routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# audio_files
+# Background Music Extractor
+
+This repository contains a simple web application that extracts background music from an uploaded song.
+It uses `pydub` to approximate vocal removal by subtracting stereo channels.
+
+## Requirements
+- Python 3.12+
+ - `flask`
+ - `pydub`
+- `ffmpeg` in your PATH for audio conversion
+
+Install dependencies:
+```bash
+pip install flask pydub
+```
+
+## Running the app
+```bash
+python server.py
+```
+Then open `http://localhost:5000` in your browser and upload a song. The app
+will return a `background.wav` file containing the approximated instrumental.
+Uploads are sent to `/api/process` both locally and on Vercel.
+
+## Deploying to Vercel
+Vercel will automatically detect the Python function in `api/process.py`. The
+static `index.html` at the repository root loads the app and sends requests to
+`/api/process`, which is handled by that serverless function.
+
+1. Install the Vercel CLI and run `vercel` to deploy.
+2. Ensure `ffmpeg` is available in your deployment environment (Vercel build
+   step) for audio conversion.

--- a/api/process.py
+++ b/api/process.py
@@ -1,0 +1,23 @@
+import os
+import tempfile
+from flask import Flask, request, send_file
+from background import isolate_background
+
+app = Flask(__name__)
+
+@app.route('/api/process', methods=['POST'])
+def process():
+    if 'file' not in request.files:
+        return 'No file uploaded', 400
+    file = request.files['file']
+    if file.filename == '':
+        return 'No selected file', 400
+    with tempfile.TemporaryDirectory() as tmpdir:
+        src_path = os.path.join(tmpdir, 'input')
+        dst_path = os.path.join(tmpdir, 'output.wav')
+        file.save(src_path)
+        isolate_background(src_path, dst_path)
+        return send_file(dst_path, as_attachment=True, download_name='background.wav')
+
+def handler(environ, start_response):
+    return app(environ, start_response)

--- a/background.py
+++ b/background.py
@@ -1,0 +1,12 @@
+from pydub import AudioSegment
+
+
+def isolate_background(src_path: str, dst_path: str) -> None:
+    """Extract background music by subtracting stereo channels."""
+    song = AudioSegment.from_file(src_path)
+    if song.channels == 2:
+        left, right = song.split_to_mono()
+        background = left.overlay(right.invert_phase())
+    else:
+        background = song
+    background.export(dst_path, format='wav')

--- a/index.html
+++ b/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Background Music Extractor</title>
+</head>
+<body>
+    <h1>Background Music Extractor</h1>
+    <form id="uploadForm">
+        <input type="file" name="file" accept="audio/*" required />
+        <button type="submit">Upload</button>
+    </form>
+    <div id="result" style="margin-top:20px;"></div>
+<script>
+document.getElementById('uploadForm').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const formData = new FormData(this);
+    const response = await fetch('/api/process', {
+        method: 'POST',
+        body: formData
+    });
+    if (response.ok) {
+        const blob = await response.blob();
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = 'background.wav';
+        link.textContent = 'Download Background Music';
+        const result = document.getElementById('result');
+        result.innerHTML = '';
+        result.appendChild(link);
+    } else {
+        alert('Error processing file');
+    }
+});
+</script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+pydub

--- a/server.py
+++ b/server.py
@@ -1,0 +1,27 @@
+import os
+import tempfile
+from flask import Flask, request, send_file
+from background import isolate_background
+
+app = Flask(__name__)
+
+@app.route('/', methods=['GET'])
+def index():
+    return send_file('index.html')
+
+@app.route('/api/process', methods=['POST'])
+def process():
+    if 'file' not in request.files:
+        return 'No file uploaded', 400
+    file = request.files['file']
+    if file.filename == '':
+        return 'No selected file', 400
+    with tempfile.TemporaryDirectory() as tmpdir:
+        src_path = os.path.join(tmpdir, 'input')
+        dst_path = os.path.join(tmpdir, 'output.wav')
+        file.save(src_path)
+        isolate_background(src_path, dst_path)
+        return send_file(dst_path, as_attachment=True, download_name='background.wav')
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- use `/api/process` path for both local and Vercel deployments
- clarify upload route in README

## Testing
- `python -m py_compile server.py api/process.py background.py`
- `python server.py` *(fails without ffmpeg)*

------
https://chatgpt.com/codex/tasks/task_e_688659d9d54c83338056173cf6bc7320